### PR TITLE
Fix bucket name mismatch between ingest and ETL

### DIFF
--- a/src/ingest/dump_loop.py
+++ b/src/ingest/dump_loop.py
@@ -11,7 +11,7 @@ from ingest.tfl_fetcher import fetch  # your async fetcher
 S3_ENDPOINT = os.getenv("S3_ENDPOINT", "http://localhost:9000")
 S3_ACCESS_KEY = os.getenv("S3_ACCESS_KEY", "minio")
 S3_SECRET_KEY = os.getenv("S3_SECRET_KEY", "minio123")
-BUCKET = "raw-bick-status"
+BUCKET = "raw-bike-status"
 
 
 async def ensure_bucket(s3, name: str) -> None:


### PR DESCRIPTION
## Summary
- fix the bucket name in `dump_loop` to match `load_one`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad609a5a4832bb77a0822104b557b